### PR TITLE
typo fixed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { KDBData, KDBCourse } from '../types'
 
 // Import utils
 import * as arrayUtil from './util/array'
-const Iconv = require('Iconv').Iconv
+const Iconv = require('iconv').Iconv
 
 // Export data types
 export { KDBData, KDBCourse }


### PR DESCRIPTION
When I do `yarn run parse kdb.csv`:
```bash
$ node dist/index.js kdb.csv
module.js:549
    throw err;
    ^

Error: Cannot find module 'Iconv'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/eggplants/prog/twinkle-parser/dist/index.js:16:15)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
So I fixed `src/index.ts`. Please confirm it.
Thanks.