### PR TITLE
feat: Add fields option to CLI bin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,21 @@ import * as arrayUtil from './util/array'
 // Export data types
 export { KDBData, KDBCourse }
 
+export const FIELD_KEYS = [
+  'title',
+  'termStr',
+  'terms',
+
+  'periodStr',
+  'periods',
+
+  'rooms',
+  'instructors',
+
+  'overview',
+  'remarks',
+]
+
 /**
  * Parse csv string to structured KDBData
  * @param csvData

--- a/tests/bin.test.ts
+++ b/tests/bin.test.ts
@@ -44,6 +44,32 @@ describe('CLI', () => {
     })
   })
 
+  test('Basic with fields option', done => {
+    const pathToSample = path.resolve(__dirname, './data/sample.csv')
+    const parsed = {
+      AB10001: {
+        title: '授業名',
+      },
+      AB10501: {
+        title: '授業名',
+      },
+    }
+
+    exec(
+      pathToBin + ' ' + pathToSample + ' --fields title',
+      (error, stdout, stderr) => {
+        if (error) throw error
+        try {
+          expect(JSON.parse(stdout)).toMatchObject(parsed)
+          expect(stderr).toBe('')
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
+    )
+  })
+
   test('Basic with data with headline', done => {
     const pathToSample = path.resolve(
       __dirname,


### PR DESCRIPTION
## New feature: `--fields` option

`twinkle-parser input.csv --fields title`

```json
{
  "AB10001": {
    "title": "授業名",
 },
 "AB10501": {
   "title": "授業名",
 },
}
```