### PR TITLE
fix: Separate \s and ,[月火水木金土日](#144)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export default function parse(csvData: string): KDBData {
     const overview = r[9]
     const remarks = r[10]
 
-    termStr.split('\n').forEach((term, i, self) => {
+    termStr.split(/\s|,(?=[月火水木金土日])/).forEach((term, i, self) => {
       if (term.match(/^(春|秋)([ABC]+)(.*)$/)) {
         const season = RegExp.$1
         const mod = RegExp.$2

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,9 @@ export default function parse(csvData: string): KDBData {
     })
 
     // Normalization
+    // Sort terms
+    terms.sort()
+
     // Concat consequtive period expressions
     for (let i = 0; i < periods.length; i++) {
       const a = periods[i]

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -22,22 +22,62 @@ describe('parse', () => {
   })
 
   test('Multi terms', () => {
-    const csv =
-      '"0000000","","","","","秋ABC","","","","","","","","","0000000","",""'
-    const parsed: KDBData = {
-      '0000000': {
-        title: '',
-        termStr: '秋ABC',
-        terms: [3, 4, 5],
-        periodStr: '',
-        periods: [],
-        rooms: [],
-        instructors: [],
-        overview: '',
-        remarks: '',
-      },
+    {
+      const csv =
+        '"0000000","","","","","秋ABC","","","","","","","","","0000000","",""'
+      const parsed: KDBData = {
+        '0000000': {
+          title: '',
+          termStr: '秋ABC',
+          terms: [3, 4, 5],
+          periodStr: '',
+          periods: [],
+          rooms: [],
+          instructors: [],
+          overview: '',
+          remarks: '',
+        },
+      }
+      expect(parse(csv)).toMatchObject(parsed)
     }
-    expect(parse(csv)).toMatchObject(parsed)
+
+    {
+      const csv =
+        '"0000000","","","","","秋AB\n秋C","","","","","","","","","0000000","",""'
+      const parsed: KDBData = {
+        '0000000': {
+          title: '',
+          termStr: '秋AB\n秋C',
+          terms: [3, 4, 5],
+          periodStr: '',
+          periods: [],
+          rooms: [],
+          instructors: [],
+          overview: '',
+          remarks: '',
+        },
+      }
+      expect(parse(csv)).toMatchObject(parsed)
+    }
+
+    {
+      const csv =
+        '"0000000","","","","","秋AB 秋C","","","","","","","","","0000000","",""'
+      const parsed: KDBData = {
+        '0000000': {
+          title: '',
+          termStr: '秋AB 秋C',
+          terms: [3, 4, 5],
+          periodStr: '',
+          periods: [],
+          rooms: [],
+          instructors: [],
+          overview: '',
+          remarks: '',
+        },
+      }
+      expect(parse(csv)).toMatchObject(parsed)
+    }
   })
 
   test('Multi periods', () => {


### PR DESCRIPTION
Fixes #144